### PR TITLE
feat(admin): add temporary inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "house-moving-out-fe",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -151,7 +151,19 @@
     },
     "list": {
       "actions": {
-        "label": "Actions"
+        "delete": {
+          "cancel": "Cancel",
+          "description": "Do you really want to delete this inspector? This change cannot be undone. Continue?",
+          "submit": "Delete",
+          "title": "Delete Inspector"
+        },
+        "label": "Actions",
+        "updateToTemporary": {
+          "cancel": "Cancel",
+          "description": "Do you really want to update inspector to temporary inspector which can be assigned manually? This change cannot be undone. Continue?",
+          "submit": "Update to Temporary",
+          "title": "Update Inspector to Temporary"
+        }
       },
       "summary": {
         "female": "Female Inspectors",

--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -157,6 +157,9 @@
         "female": "Female Inspectors",
         "male": "Male Inspectors"
       },
+      "temporary": {
+        "label": "Temporary"
+      },
       "title": "Inspector List"
     },
     "temporaryCreate": {

--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -158,6 +158,9 @@
         "male": "Male Inspectors"
       },
       "title": "Inspector List"
+    },
+    "temporaryCreate": {
+      "action": "Add Temporary Inspector"
     }
   },
   "result": {

--- a/public/locales/ko/admin.json
+++ b/public/locales/ko/admin.json
@@ -156,6 +156,9 @@
         "female": "여자 검사위원",
         "male": "남자 검사위원"
       },
+      "temporary": {
+        "label": "임시 검사위원"
+      },
       "title": "검사위원 목록"
     },
     "temporaryCreate": {

--- a/public/locales/ko/admin.json
+++ b/public/locales/ko/admin.json
@@ -157,6 +157,9 @@
         "male": "남자 검사위원"
       },
       "title": "검사위원 목록"
+    },
+    "temporaryCreate": {
+      "action": "임시 검사위원 추가"
     }
   },
   "result": {

--- a/public/locales/ko/admin.json
+++ b/public/locales/ko/admin.json
@@ -150,7 +150,19 @@
     },
     "list": {
       "actions": {
-        "label": "액션"
+        "delete": {
+          "cancel": "취소",
+          "description": "정말 이 검사위원을 삭제하시겠습니까? 이 변경은 되돌릴 수 없습니다. 계속하시겠습니까?",
+          "submit": "삭제하기",
+          "title": "검사위원 삭제"
+        },
+        "label": "액션",
+        "updateToTemporary": {
+          "cancel": "취소",
+          "description": "자동 배정과는 상관 없이 임의로 할당 가능한 임시 검사위원으로 승격시키고자 합니다. 이 변경은 되돌릴 수 없습니다. 계속하시겠습니까?",
+          "submit": "승격하기",
+          "title": "임시 검사위원으로 승격"
+        }
       },
       "summary": {
         "female": "여자 검사위원",

--- a/src/features/admin/models/index.ts
+++ b/src/features/admin/models/index.ts
@@ -2,6 +2,7 @@ import { type components } from '@/@types/api-schema';
 
 export type MoveOutSchedule = components['schemas']['MoveOutScheduleResDto'];
 export type InspectionSlot = components['schemas']['InspectionSlotResDto'];
+export type SlotInfo = components['schemas']['SlotInfoResDto'];
 export type Target = components['schemas']['InspectionTargetsGroupedByRoomResDto'];
 export type Article = components['schemas']['ArticleResDto'];
 export type ArticleDetail = components['schemas']['ArticleDetailResDto'];

--- a/src/features/admin/viewmodels/index.ts
+++ b/src/features/admin/viewmodels/index.ts
@@ -18,4 +18,5 @@ export {
   ApplicationStatus,
   type Application,
   type InspectionSlot,
+  type SlotInfo,
 } from '../models';

--- a/src/features/admin/viewmodels/queries/index.ts
+++ b/src/features/admin/viewmodels/queries/index.ts
@@ -16,3 +16,4 @@ export * from './use-database-size';
 export * from './use-bulk-update-repair';
 export * from './use-change-schedule-status';
 export * from './use-change-inspector';
+export * from './use-update-inspector-to-temporary';

--- a/src/features/admin/viewmodels/queries/use-create-temporary-inspector.ts
+++ b/src/features/admin/viewmodels/queries/use-create-temporary-inspector.ts
@@ -11,14 +11,15 @@ export const useCreateTemporaryInspector = () => {
   const queryClient = useQueryClient();
   const { t } = useTranslation('admin');
   return $api.useMutation('post', ApiPaths.InspectorController_createTemporaryInspectors, {
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['get', ApiPaths.InspectorController_getInspectors],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['get', ApiPaths.ScheduleController_findInspectorsByScheduleUuid],
-      });
-    },
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['get', ApiPaths.InspectorController_getInspectors],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['get', ApiPaths.ScheduleController_findInspectorsByScheduleUuid],
+        }),
+      ]),
     onError: (error) => {
       if (error.statusCode === 401) {
         toast.error(t('error.unauthorized', { ns: 'common' }));

--- a/src/features/admin/viewmodels/queries/use-create-temporary-inspector.ts
+++ b/src/features/admin/viewmodels/queries/use-create-temporary-inspector.ts
@@ -1,0 +1,30 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { $api } from '@/common/lib';
+
+import { ApiPaths } from '../../models';
+
+export const useCreateTemporaryInspector = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('admin');
+  return $api.useMutation('post', ApiPaths.InspectorController_createTemporaryInspectors, {
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['get', ApiPaths.InspectorController_getInspectors],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['get', ApiPaths.ScheduleController_findInspectorsByScheduleUuid],
+      });
+    },
+    onError: (error) => {
+      if (error.statusCode === 401) {
+        toast.error(t('error.unauthorized', { ns: 'common' }));
+      } else {
+        toast.error(t('error.internalServerError', { ns: 'common' }));
+      }
+    },
+  });
+};

--- a/src/features/admin/viewmodels/queries/use-delete-inspector.ts
+++ b/src/features/admin/viewmodels/queries/use-delete-inspector.ts
@@ -12,9 +12,14 @@ export const useDeleteInspector = () => {
   const { t } = useTranslation('admin');
   return $api.useMutation('delete', ApiPaths.InspectorController_deleteInspector, {
     onSuccess: () =>
-      queryClient.invalidateQueries({
-        queryKey: ['get', ApiPaths.ScheduleController_findInspectorsByScheduleUuid],
-      }),
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['get', ApiPaths.InspectorController_getInspectors],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['get', ApiPaths.ScheduleController_findInspectorsByScheduleUuid],
+        }),
+      ]),
     onError: (error) => {
       if (error.statusCode === 401) {
         toast.error(t('error.unauthorized', { ns: 'common' }));

--- a/src/features/admin/viewmodels/queries/use-inspectors-of-schedule.ts
+++ b/src/features/admin/viewmodels/queries/use-inspectors-of-schedule.ts
@@ -10,8 +10,8 @@ import { ApiPaths } from '../../models';
 export const useInspectorsOfSchedule = (scheduleUuid: string) => {
   const { data, error, isError, isLoading } = $api.useQuery(
     'get',
-    ApiPaths.ScheduleController_findInspectorsByScheduleUuid,
-    { params: { path: { uuid: scheduleUuid } } },
+    ApiPaths.InspectorController_getInspectors,
+    { params: { query: { scheduleUuid } } },
     {
       retry(count, error) {
         if (error?.statusCode === 404 || error?.statusCode === 400) return false;

--- a/src/features/admin/viewmodels/queries/use-update-inspector-to-temporary.ts
+++ b/src/features/admin/viewmodels/queries/use-update-inspector-to-temporary.ts
@@ -7,10 +7,11 @@ import { $api } from '@/common/lib';
 
 import { ApiPaths } from '../../models';
 
-export const useCreateInspector = () => {
+export const useUpdateInspectorToTemporary = () => {
   const queryClient = useQueryClient();
   const { t } = useTranslation('admin');
-  return $api.useMutation('post', ApiPaths.InspectorController_createInspectors, {
+
+  return $api.useMutation('patch', ApiPaths.InspectorController_updateInspectorToTemporary, {
     onSuccess: () =>
       Promise.all([
         queryClient.invalidateQueries({
@@ -23,6 +24,8 @@ export const useCreateInspector = () => {
     onError: (error) => {
       if (error.statusCode === 401) {
         toast.error(t('error.unauthorized', { ns: 'common' }));
+      } else if (error?.statusCode === 404) {
+        toast.error(t('inspectors.error.notFound'));
       } else {
         toast.error(t('error.internalServerError', { ns: 'common' }));
       }

--- a/src/features/admin/viewmodels/use-create-inspector-form.ts
+++ b/src/features/admin/viewmodels/use-create-inspector-form.ts
@@ -48,7 +48,7 @@ const useCreateInspectorFormInternal = (scheduleUuid: string, isTemporary = fals
       toast.success(t('inspectors.create.succeed'));
       await navigate({
         to: '/admin/schedules/$uuid/inspectors',
-        from: '/admin/schedules/$uuid/inspectors/new',
+        params: { uuid: scheduleUuid },
       });
     },
     () => {

--- a/src/features/admin/viewmodels/use-create-inspector-form.ts
+++ b/src/features/admin/viewmodels/use-create-inspector-form.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 
 import { Gender } from '../models';
 import { useCreateInspector } from './queries/use-create-inspector';
+import { useCreateTemporaryInspector } from './queries/use-create-temporary-inspector';
 
 const schema = z.object({
   name: z.string().min(1),
@@ -18,7 +19,7 @@ const schema = z.object({
   availableSlotUuids: z.uuid().array(),
 });
 
-export const useCreateInspectorForm = (scheduleUuid: string) => {
+const useCreateInspectorFormInternal = (scheduleUuid: string, isTemporary = false) => {
   const { register, handleSubmit, formState, setValue, getValues, control } = useForm({
     resolver: zodResolver(schema),
     defaultValues: {
@@ -26,15 +27,24 @@ export const useCreateInspectorForm = (scheduleUuid: string) => {
     },
   });
   const { mutateAsync: createInspector } = useCreateInspector();
+  const { mutateAsync: createTemporaryInspector } = useCreateTemporaryInspector();
   const { t } = useTranslation('admin');
   const navigate = useNavigate();
 
   const onSubmit = handleSubmit(
     async (data) => {
-      await createInspector({
-        params: { query: { scheduleUuid } },
-        body: { inspectors: [data] },
-      });
+      if (isTemporary) {
+        const sanitized = schema.omit({ availableSlotUuids: true }).parse(data);
+        await createTemporaryInspector({
+          params: { query: { scheduleUuid } },
+          body: { inspectors: [sanitized] },
+        });
+      } else {
+        await createInspector({
+          params: { query: { scheduleUuid } },
+          body: { inspectors: [data] },
+        });
+      }
       toast.success(t('inspectors.create.succeed'));
       await navigate({
         to: '/admin/schedules/$uuid/inspectors',
@@ -68,3 +78,8 @@ export const useCreateInspectorForm = (scheduleUuid: string) => {
     slots,
   };
 };
+
+export const useCreateInspectorForm = (scheduleUuid: string) =>
+  useCreateInspectorFormInternal(scheduleUuid);
+export const useCreateTemporaryInspectorForm = (scheduleUuid: string) =>
+  useCreateInspectorFormInternal(scheduleUuid, true);

--- a/src/features/admin/views/components/inspector-changer/index.tsx
+++ b/src/features/admin/views/components/inspector-changer/index.tsx
@@ -59,7 +59,9 @@ function ChangeConfirmDialog({
       </Dialog.Body>
       <Dialog.Footer className={cn(isFull && 'flex-col')}>
         <Dialog.Close asChild>
-          <Button disabled={loading}>{t('application.detail.changeInspector.cancel')}</Button>
+          <Button variant="subtle" disabled={loading}>
+            {t('application.detail.changeInspector.cancel')}
+          </Button>
         </Dialog.Close>
         {isFull ? (
           applications.applications.map((a) => (

--- a/src/features/admin/views/components/inspector-changer/index.tsx
+++ b/src/features/admin/views/components/inspector-changer/index.tsx
@@ -12,7 +12,7 @@ import {
   useInspectorsOfSchedule,
   type Application,
   type Inspector,
-  type InspectionSlot,
+  type SlotInfo,
 } from '@/features/admin/viewmodels';
 
 function ChangeConfirmDialog({
@@ -25,22 +25,22 @@ function ChangeConfirmDialog({
   confirmChange: (targetApplicationUuid?: string) => Promise<void>;
   inspector: Inspector;
   application: Application;
-  slot: InspectionSlot;
+  slot: SlotInfo;
   scheduleUuid: string;
 }) {
   const { t } = useTranslation('admin');
   const [loading, startLoading] = useTransition();
-  const { data: applications, error } = useApplicationsWithInspectorAndSlot(
-    scheduleUuid,
-    inspector.uuid,
-    slot.uuid,
-  );
+  const {
+    data: applications,
+    error,
+    isFetchedAfterMount,
+  } = useApplicationsWithInspectorAndSlot(scheduleUuid, inspector.uuid, slot.uuid);
   const { close } = useOverlayContext();
 
   if (error) return <div>{t('application.error.load')}</div>;
-  if (!applications) return <Loading containerClassName="h-full" />;
+  if (!applications || !isFetchedAfterMount) return <Loading containerClassName="h-full" />;
 
-  const isFull = applications.applications.length >= 2;
+  const isFull = applications.applications.length >= 2 && !inspector.isTemporary;
 
   return (
     <>
@@ -116,9 +116,7 @@ export function InspectorChanger({
           ...i,
           slot: i.availableSlots.find((s) => s.uuid === application.inspectionSlot.uuid),
         }))
-        .filter((i): i is { [K in keyof typeof i]: NonNullable<(typeof i)[K]> } =>
-          isNotNil(i.slot),
-        ) ?? [],
+        .filter((i) => isNotNil(i.slot) || i.isTemporary) ?? [],
     [inspectors, application.inspectionSlot.uuid],
   );
   const inspectorMap = useMemo(
@@ -139,7 +137,7 @@ export function InspectorChanger({
               application={application}
               scheduleUuid={scheduleUuid}
               inspector={inspector}
-              slot={inspector.slot}
+              slot={application.inspectionSlot}
               confirmChange={(targetApplicationUuid) =>
                 changeInspector({
                   params: { path: { uuid: application.uuid } },

--- a/src/features/admin/views/frames/create-temporary-inspector-frame.tsx
+++ b/src/features/admin/views/frames/create-temporary-inspector-frame.tsx
@@ -1,0 +1,86 @@
+import { useParams } from '@tanstack/react-router';
+
+import { useTranslation } from 'react-i18next';
+
+import { Button, Input, Loading } from '@/common/components';
+
+import {
+  Gender,
+  useCreateTemporaryInspectorForm,
+  useGetMoveOutScheduleQuery,
+  useInspectorsOfSchedule,
+} from '../../viewmodels';
+
+export function CreateTemporaryInspectorFrame() {
+  const { t } = useTranslation('admin');
+  const { uuid } = useParams({
+    from: '/_auth-required/admin/schedules/$uuid/inspectors/temporary',
+  });
+  const { register, onSubmit, isSubmitting, setGender, gender, errors } =
+    useCreateTemporaryInspectorForm(uuid);
+  const { data: inspectors, isNotFound: isInspectorsNotFound } = useInspectorsOfSchedule(uuid);
+  const { data: schedule, isNotFound: isScheduleNotFound } = useGetMoveOutScheduleQuery(uuid);
+
+  if (isScheduleNotFound || isInspectorsNotFound)
+    return <div className="p-4">{t('inspectors.error.notFound')}</div>;
+  if (!schedule || !inspectors) return <Loading />;
+
+  return (
+    <form className="flex flex-1 flex-col gap-4 p-4" onSubmit={onSubmit}>
+      <div>
+        <label>
+          {t('inspectors.create.name.label')}:
+          <Input
+            error={errors.name?.message}
+            placeholder={t('inspectors.create.name.placeholder')}
+            {...register('name')}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          {t('inspectors.create.email.label')}:
+          <Input
+            error={errors.email?.message}
+            placeholder={t('inspectors.create.email.placeholder')}
+            {...register('email')}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          {t('inspectors.create.gender.label')}:
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant={gender === Gender.MALE ? 'default' : 'outline'}
+              onClick={() => setGender(Gender.MALE)}
+            >
+              {t('gender.male')}
+            </Button>
+            <Button
+              type="button"
+              variant={gender === Gender.FEMALE ? 'default' : 'outline'}
+              onClick={() => setGender(Gender.FEMALE)}
+            >
+              {t('gender.female')}
+            </Button>
+          </div>
+        </label>
+      </div>
+      <div>
+        <label>
+          {t('inspectors.create.studentNumber.label')}
+          <Input
+            error={errors.studentNumber?.message}
+            placeholder={t('inspectors.create.studentNumber.placeholder')}
+            {...register('studentNumber')}
+          />
+        </label>
+      </div>
+      <Button disabled={isSubmitting} className="mt-auto">
+        {t('inspectors.create.action')}
+      </Button>
+    </form>
+  );
+}

--- a/src/features/admin/views/frames/index.ts
+++ b/src/features/admin/views/frames/index.ts
@@ -4,6 +4,7 @@ export * from './schedule-detail-frame';
 export * from './create-schedule-frame';
 export * from './inspectors-list-frame';
 export * from './create-inspector-frame';
+export * from './create-temporary-inspector-frame';
 export * from './schedule-layout-frame';
 export * from './target-list-frame';
 export * from './application-list-frame';

--- a/src/features/admin/views/frames/inspectors-list-frame.tsx
+++ b/src/features/admin/views/frames/inspectors-list-frame.tsx
@@ -2,7 +2,7 @@ import { Link, useParams } from '@tanstack/react-router';
 
 import dayjs from 'dayjs';
 import { countBy } from 'es-toolkit';
-import { Check, Trash } from 'lucide-react';
+import { ArrowLeftRight, Check, Trash } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Button, Loading } from '@/common/components';
@@ -13,6 +13,7 @@ import {
   useDeleteInspector,
   useGetMoveOutScheduleQuery,
   useInspectorsOfSchedule,
+  useUpdateInspectorToTemporary,
   type Inspector,
   type MoveOutScheduleWithSlots,
 } from '../../viewmodels';
@@ -41,6 +42,7 @@ export function InspectorsListFrame() {
   const { t } = useTranslation('admin');
   const { data: schedule, isNotFound: isScheduleNotFound } = useGetMoveOutScheduleQuery(uuid);
   const { mutate: deleteInspector } = useDeleteInspector();
+  const { mutate: updateInspectorToTemporary } = useUpdateInspectorToTemporary();
 
   if (isScheduleNotFound || isInspectorsNotFound)
     return <div className="p-4">{t('schedule.detail.notFound')}</div>;
@@ -89,7 +91,21 @@ export function InspectorsListFrame() {
                   )}
                 </td>
                 <td className="py-1">
-                  <div className="flex justify-center">
+                  <div className="flex justify-center gap-2">
+                    <Button
+                      size="icon"
+                      onClick={() =>
+                        // TODO: add confirm modal after HMF-36
+                        updateInspectorToTemporary({
+                          params: {
+                            query: { scheduleUuid: uuid },
+                            path: { uuid: i.uuid },
+                          },
+                        })
+                      }
+                    >
+                      <ArrowLeftRight />
+                    </Button>
                     <Button
                       size="icon"
                       className="bg-red-600"

--- a/src/features/admin/views/frames/inspectors-list-frame.tsx
+++ b/src/features/admin/views/frames/inspectors-list-frame.tsx
@@ -61,7 +61,9 @@ function UpdateInspectorToTemporaryDialog({
       </Dialog.Body>
       <Dialog.Footer>
         <Dialog.Close asChild>
-          <Button disabled={loading}>{t('cancel')}</Button>
+          <Button variant="subtle" disabled={loading}>
+            {t('cancel')}
+          </Button>
         </Dialog.Close>
         <Button
           className="w-full"
@@ -105,7 +107,9 @@ function DeleteInspectorDialog({
       </Dialog.Body>
       <Dialog.Footer>
         <Dialog.Close asChild>
-          <Button disabled={loading}>{t('cancel')}</Button>
+          <Button variant="subtle" disabled={loading}>
+            {t('cancel')}
+          </Button>
         </Dialog.Close>
         <Button
           className="w-full"

--- a/src/features/admin/views/frames/inspectors-list-frame.tsx
+++ b/src/features/admin/views/frames/inspectors-list-frame.tsx
@@ -2,7 +2,7 @@ import { Link, useParams } from '@tanstack/react-router';
 
 import dayjs from 'dayjs';
 import { countBy } from 'es-toolkit';
-import { Trash } from 'lucide-react';
+import { Check, Trash } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Button, Loading } from '@/common/components';
@@ -60,6 +60,7 @@ export function InspectorsListFrame() {
               <th>{t('inspectors.create.studentNumber.label')}</th>
               <th>{t('inspectors.create.gender.label')}</th>
               <th>{t('inspectors.create.slots.label')}</th>
+              <th>{t('inspectors.list.temporary.label')}</th>
               <th>{t('inspectors.list.actions.label')}</th>
             </tr>
           </thead>
@@ -79,6 +80,13 @@ export function InspectorsListFrame() {
                   )
                     .map((r) => `${r.start.format('ddd HH:mm')}~${r.end.format('ddd HH:mm')}`)
                     .join('\n')}
+                </td>
+                <td>
+                  {i.isTemporary && (
+                    <div className="flex items-center justify-center">
+                      <Check />
+                    </div>
+                  )}
                 </td>
                 <td className="py-1">
                   <div className="flex justify-center">

--- a/src/features/admin/views/frames/inspectors-list-frame.tsx
+++ b/src/features/admin/views/frames/inspectors-list-frame.tsx
@@ -9,6 +9,7 @@ import { Button, Loading } from '@/common/components';
 
 import {
   Gender,
+  ScheduleStatus,
   useDeleteInspector,
   useGetMoveOutScheduleQuery,
   useInspectorsOfSchedule,
@@ -115,11 +116,20 @@ export function InspectorsListFrame() {
           slots={femaleSlots}
         />
       </div>
-      <Button asChild>
-        <Link to="/admin/schedules/$uuid/inspectors/new" params={{ uuid }}>
-          {t('inspectors.create.action')}
-        </Link>
-      </Button>
+      {schedule.status === ScheduleStatus.DRAFT && (
+        <Button asChild>
+          <Link to="/admin/schedules/$uuid/inspectors/new" params={{ uuid }}>
+            {t('inspectors.create.action')}
+          </Link>
+        </Button>
+      )}
+      {schedule.status === ScheduleStatus.ACTIVE && (
+        <Button asChild>
+          <Link to="/admin/schedules/$uuid/inspectors/temporary" params={{ uuid }}>
+            {t('inspectors.temporaryCreate.action')}
+          </Link>
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/features/admin/views/frames/inspectors-list-frame.tsx
+++ b/src/features/admin/views/frames/inspectors-list-frame.tsx
@@ -1,3 +1,5 @@
+import { useTransition } from 'react';
+
 import { Link, useParams } from '@tanstack/react-router';
 
 import dayjs from 'dayjs';
@@ -5,7 +7,8 @@ import { countBy } from 'es-toolkit';
 import { ArrowLeftRight, Check, Trash } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-import { Button, Loading } from '@/common/components';
+import { Button, Dialog, Loading } from '@/common/components';
+import { overlay, useOverlayContext } from '@/common/lib';
 
 import {
   Gender,
@@ -36,13 +39,100 @@ const getRequiredCountSlots = (
     }));
 };
 
+function UpdateInspectorToTemporaryDialog({
+  scheduleUuid,
+  inspector,
+}: {
+  scheduleUuid: string;
+  inspector: Inspector;
+}) {
+  const { mutateAsync: updateInspectorToTemporary } = useUpdateInspectorToTemporary();
+  const [loading, startLoading] = useTransition();
+  const { close } = useOverlayContext();
+  const { t } = useTranslation('admin', { keyPrefix: 'inspectors.list.actions.updateToTemporary' });
+
+  return (
+    <>
+      <Dialog.Header>
+        <Dialog.Title>{t('title')}</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.Body>
+        <Dialog.Description>{t('description')}</Dialog.Description>
+      </Dialog.Body>
+      <Dialog.Footer>
+        <Dialog.Close asChild>
+          <Button disabled={loading}>{t('cancel')}</Button>
+        </Dialog.Close>
+        <Button
+          className="w-full"
+          disabled={loading}
+          onClick={() =>
+            startLoading(() =>
+              updateInspectorToTemporary({
+                params: { query: { scheduleUuid }, path: { uuid: inspector.uuid } },
+              })
+                .then(close)
+                .catch(() => {}),
+            )
+          }
+        >
+          {t('submit')}
+        </Button>
+      </Dialog.Footer>
+    </>
+  );
+}
+
+function DeleteInspectorDialog({
+  scheduleUuid,
+  inspector,
+}: {
+  scheduleUuid: string;
+  inspector: Inspector;
+}) {
+  const { mutateAsync: deleteInspector } = useDeleteInspector();
+  const [loading, startLoading] = useTransition();
+  const { close } = useOverlayContext();
+  const { t } = useTranslation('admin', { keyPrefix: 'inspectors.list.actions.delete' });
+
+  return (
+    <>
+      <Dialog.Header>
+        <Dialog.Title>{t('title')}</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.Body>
+        <Dialog.Description>{t('description')}</Dialog.Description>
+      </Dialog.Body>
+      <Dialog.Footer>
+        <Dialog.Close asChild>
+          <Button disabled={loading}>{t('cancel')}</Button>
+        </Dialog.Close>
+        <Button
+          className="w-full"
+          variant="failed"
+          disabled={loading}
+          onClick={() =>
+            startLoading(() =>
+              deleteInspector({
+                params: { query: { scheduleUuid }, path: { uuid: inspector.uuid } },
+              })
+                .then(close)
+                .catch(() => {}),
+            )
+          }
+        >
+          {t('submit')}
+        </Button>
+      </Dialog.Footer>
+    </>
+  );
+}
+
 export function InspectorsListFrame() {
   const { uuid } = useParams({ from: '/_auth-required/admin/schedules/$uuid/inspectors/' });
   const { data: inspectors, isNotFound: isInspectorsNotFound } = useInspectorsOfSchedule(uuid);
   const { t } = useTranslation('admin');
   const { data: schedule, isNotFound: isScheduleNotFound } = useGetMoveOutScheduleQuery(uuid);
-  const { mutate: deleteInspector } = useDeleteInspector();
-  const { mutate: updateInspectorToTemporary } = useUpdateInspectorToTemporary();
 
   if (isScheduleNotFound || isInspectorsNotFound)
     return <div className="p-4">{t('schedule.detail.notFound')}</div>;
@@ -94,14 +184,13 @@ export function InspectorsListFrame() {
                   <div className="flex justify-center gap-2">
                     <Button
                       size="icon"
+                      disabled={i.isTemporary}
                       onClick={() =>
-                        // TODO: add confirm modal after HMF-36
-                        updateInspectorToTemporary({
-                          params: {
-                            query: { scheduleUuid: uuid },
-                            path: { uuid: i.uuid },
-                          },
-                        })
+                        overlay.open(() => (
+                          <Dialog.Root>
+                            <UpdateInspectorToTemporaryDialog scheduleUuid={uuid} inspector={i} />
+                          </Dialog.Root>
+                        ))
                       }
                     >
                       <ArrowLeftRight />
@@ -110,13 +199,11 @@ export function InspectorsListFrame() {
                       size="icon"
                       className="bg-red-600"
                       onClick={() =>
-                        // TODO: add confirm modal after HMF-36
-                        deleteInspector({
-                          params: {
-                            query: { scheduleUuid: uuid },
-                            path: { uuid: i.uuid },
-                          },
-                        })
+                        overlay.open(() => (
+                          <Dialog.Root>
+                            <DeleteInspectorDialog scheduleUuid={uuid} inspector={i} />
+                          </Dialog.Root>
+                        ))
                       }
                     >
                       <Trash />

--- a/src/routes/_auth-required/admin/schedules/$uuid/inspectors/temporary.tsx
+++ b/src/routes/_auth-required/admin/schedules/$uuid/inspectors/temporary.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { CreateTemporaryInspectorFrame } from '@/features/admin';
+
+export const Route = createFileRoute('/_auth-required/admin/schedules/$uuid/inspectors/temporary')({
+  component: CreateTemporaryInspectorFrame,
+});


### PR DESCRIPTION


https://github.com/user-attachments/assets/1b951b11-a88d-4f63-85c6-ca8a6fd2ff2a

- 임시 검사위원의 경우에는 특정 슬롯에 할당된 개수와 상관 없이 수동 할당이 가능합니다
- 기존 검사위원을 임시 검사위원으로 승격할 수 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 임시 검사자 생성 플로우 추가(전용 생성 화면 및 폼 검증 포함)
  * 기존 검사자를 임시 상태로 전환하는 확인 다이얼로그 추가
  * 검사자 삭제 시 확인 다이얼로그 추가
  * 검사자 목록에 "임시" 구분 표시 및 임시 전환/삭제 액션 추가
  * 스케줄 상태에 따라 검사자 생성 경로가 조건부로 분기됨
  * 관리자 화면용 문구(대화상자/버튼/레이블) 한국어·영어 번역 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->