### PR TITLE
feat: add superadmin admin management page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "house-moving-out-fe",
-  "version": "0.4.36",
+  "version": "0.4.37",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -1,4 +1,56 @@
 {
+  "admins": {
+    "nav": "Admin management",
+    "title": "Admin management",
+    "add": "Add admin",
+    "empty": "No admins registered.",
+    "columns": {
+      "name": "Name",
+      "email": "Email",
+      "studentNumber": "Student #",
+      "role": "Role",
+      "createdAt": "Added at",
+      "actions": "Actions"
+    },
+    "role": {
+      "superadmin": "Super admin",
+      "admin": "Admin"
+    },
+    "create": {
+      "title": "Add admin",
+      "name": {
+        "label": "Name",
+        "placeholder": "Enter name"
+      },
+      "studentNumber": {
+        "label": "Student #",
+        "placeholder": "8-digit student number"
+      },
+      "submit": "Add",
+      "cancel": "Cancel",
+      "success": "Admin has been added.",
+      "error": {
+        "formError": "Please check the form fields."
+      }
+    },
+    "actions": {
+      "delete": {
+        "title": "Remove admin",
+        "description": "Remove admin privileges from {{name}}?",
+        "submit": "Remove",
+        "cancel": "Cancel"
+      },
+      "transfer": {
+        "title": "Transfer super admin",
+        "description": "Super admin role will be transferred to {{name}}. You will become a regular admin.",
+        "submit": "Transfer",
+        "cancel": "Cancel"
+      }
+    },
+    "error": {
+      "conflict": "Could not process the request. Please verify user information."
+    }
+  },
   "application": {
     "detail": {
       "appliedAt": "Applied At",

--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -1,23 +1,33 @@
 {
   "admins": {
-    "nav": "Admin management",
-    "title": "Admin management",
-    "add": "Add admin",
-    "empty": "No admins registered.",
-    "columns": {
-      "name": "Name",
-      "email": "Email",
-      "studentNumber": "Student #",
-      "role": "Role",
-      "createdAt": "Added at",
-      "actions": "Actions"
+    "actions": {
+      "delete": {
+        "cancel": "Cancel",
+        "description": "Remove admin privileges from {{name}}?",
+        "submit": "Remove",
+        "title": "Remove admin"
+      },
+      "transfer": {
+        "cancel": "Cancel",
+        "description": "Super admin role will be transferred to {{name}}. You will become a regular admin.",
+        "submit": "Transfer",
+        "title": "Transfer super admin"
+      }
     },
-    "role": {
-      "superadmin": "Super admin",
-      "admin": "Admin"
+    "add": "Add admin",
+    "columns": {
+      "actions": "Actions",
+      "createdAt": "Added at",
+      "email": "Email",
+      "name": "Name",
+      "role": "Role",
+      "studentNumber": "Student #"
     },
     "create": {
-      "title": "Add admin",
+      "cancel": "Cancel",
+      "error": {
+        "formError": "Please check the form fields."
+      },
       "name": {
         "label": "Name",
         "placeholder": "Enter name"
@@ -27,29 +37,19 @@
         "placeholder": "8-digit student number"
       },
       "submit": "Add",
-      "cancel": "Cancel",
       "success": "Admin has been added.",
-      "error": {
-        "formError": "Please check the form fields."
-      }
+      "title": "Add admin"
     },
-    "actions": {
-      "delete": {
-        "title": "Remove admin",
-        "description": "Remove admin privileges from {{name}}?",
-        "submit": "Remove",
-        "cancel": "Cancel"
-      },
-      "transfer": {
-        "title": "Transfer super admin",
-        "description": "Super admin role will be transferred to {{name}}. You will become a regular admin.",
-        "submit": "Transfer",
-        "cancel": "Cancel"
-      }
-    },
+    "empty": "No admins registered.",
     "error": {
       "conflict": "Could not process the request. Please verify user information."
-    }
+    },
+    "nav": "Admin management",
+    "role": {
+      "admin": "Admin",
+      "superadmin": "Super admin"
+    },
+    "title": "Admin management"
   },
   "application": {
     "detail": {

--- a/public/locales/ko/admin.json
+++ b/public/locales/ko/admin.json
@@ -1,23 +1,33 @@
 {
   "admins": {
-    "nav": "관리자 관리",
-    "title": "관리자 관리",
-    "add": "관리자 추가",
-    "empty": "등록된 관리자가 없습니다.",
-    "columns": {
-      "name": "이름",
-      "email": "이메일",
-      "studentNumber": "학번",
-      "role": "역할",
-      "createdAt": "등록일",
-      "actions": "작업"
+    "actions": {
+      "delete": {
+        "cancel": "취소",
+        "description": "{{name}}님의 관리자 권한을 해제하시겠습니까?",
+        "submit": "삭제",
+        "title": "관리자 삭제"
+      },
+      "transfer": {
+        "cancel": "취소",
+        "description": "최고 관리자 권한이 {{name}}님에게 이전됩니다. 본인은 일반 관리자로 변경됩니다.",
+        "submit": "위임",
+        "title": "최고 관리자 위임"
+      }
     },
-    "role": {
-      "superadmin": "최고 관리자",
-      "admin": "관리자"
+    "add": "관리자 추가",
+    "columns": {
+      "actions": "작업",
+      "createdAt": "등록일",
+      "email": "이메일",
+      "name": "이름",
+      "role": "역할",
+      "studentNumber": "학번"
     },
     "create": {
-      "title": "관리자 추가",
+      "cancel": "취소",
+      "error": {
+        "formError": "입력 칸을 확인해주세요."
+      },
       "name": {
         "label": "이름",
         "placeholder": "이름을 입력해주세요"
@@ -27,29 +37,19 @@
         "placeholder": "8자리 학번"
       },
       "submit": "추가",
-      "cancel": "취소",
       "success": "관리자가 추가되었습니다.",
-      "error": {
-        "formError": "입력 칸을 확인해주세요."
-      }
+      "title": "관리자 추가"
     },
-    "actions": {
-      "delete": {
-        "title": "관리자 삭제",
-        "description": "{{name}}님의 관리자 권한을 해제하시겠습니까?",
-        "submit": "삭제",
-        "cancel": "취소"
-      },
-      "transfer": {
-        "title": "최고 관리자 위임",
-        "description": "최고 관리자 권한이 {{name}}님에게 이전됩니다. 본인은 일반 관리자로 변경됩니다.",
-        "submit": "위임",
-        "cancel": "취소"
-      }
-    },
+    "empty": "등록된 관리자가 없습니다.",
     "error": {
       "conflict": "요청을 처리할 수 없습니다. 사용자 정보를 확인해주세요."
-    }
+    },
+    "nav": "관리자 관리",
+    "role": {
+      "admin": "관리자",
+      "superadmin": "최고 관리자"
+    },
+    "title": "관리자 관리"
   },
   "application": {
     "detail": {

--- a/public/locales/ko/admin.json
+++ b/public/locales/ko/admin.json
@@ -1,4 +1,56 @@
 {
+  "admins": {
+    "nav": "관리자 관리",
+    "title": "관리자 관리",
+    "add": "관리자 추가",
+    "empty": "등록된 관리자가 없습니다.",
+    "columns": {
+      "name": "이름",
+      "email": "이메일",
+      "studentNumber": "학번",
+      "role": "역할",
+      "createdAt": "등록일",
+      "actions": "작업"
+    },
+    "role": {
+      "superadmin": "최고 관리자",
+      "admin": "관리자"
+    },
+    "create": {
+      "title": "관리자 추가",
+      "name": {
+        "label": "이름",
+        "placeholder": "이름을 입력해주세요"
+      },
+      "studentNumber": {
+        "label": "학번",
+        "placeholder": "8자리 학번"
+      },
+      "submit": "추가",
+      "cancel": "취소",
+      "success": "관리자가 추가되었습니다.",
+      "error": {
+        "formError": "입력 칸을 확인해주세요."
+      }
+    },
+    "actions": {
+      "delete": {
+        "title": "관리자 삭제",
+        "description": "{{name}}님의 관리자 권한을 해제하시겠습니까?",
+        "submit": "삭제",
+        "cancel": "취소"
+      },
+      "transfer": {
+        "title": "최고 관리자 위임",
+        "description": "최고 관리자 권한이 {{name}}님에게 이전됩니다. 본인은 일반 관리자로 변경됩니다.",
+        "submit": "위임",
+        "cancel": "취소"
+      }
+    },
+    "error": {
+      "conflict": "요청을 처리할 수 없습니다. 사용자 정보를 확인해주세요."
+    }
+  },
   "application": {
     "detail": {
       "appliedAt": "신청 일시",

--- a/src/features/admin/models/index.ts
+++ b/src/features/admin/models/index.ts
@@ -12,6 +12,10 @@ export type UpdateArticleVisibilityRequest = components['schemas']['UpdateArticl
 export type MoveOutScheduleWithSlots = components['schemas']['MoveOutScheduleWithSlotsResDto'];
 export type Inspector = components['schemas']['InspectorResDto'];
 export type Application = components['schemas']['ApplicationResDto'];
+export type AdminListItem = components['schemas']['AdminListItemDto'];
+export type AdminList = components['schemas']['AdminListDto'];
+export type CreateAdminRequest = components['schemas']['CreateAdminDto'];
+export type TransferSuperAdminRequest = components['schemas']['TransferSuperAdminDto'];
 export {
   CreateMoveOutScheduleWithTargetsFormDtoCurrentSeason as Season,
   CreateMoveOutScheduleWithTargetsFormDtoResidentGenderByHouseFloorKey as Gender,
@@ -20,6 +24,7 @@ export {
   PathsArticleGetParametersQueryType as ArticleType,
   ArticleDtoLanguage as ArticleLanguage,
   ApplicationResDtoStatus as ApplicationStatus,
+  UserDtoRole,
 } from '@/@types/api-schema';
 export { ApiPaths } from '@/@types/api-schema';
 export { default as insertSignatureContent } from './insert-signature.typ?raw';

--- a/src/features/admin/viewmodels/index.ts
+++ b/src/features/admin/viewmodels/index.ts
@@ -1,4 +1,5 @@
 export * from './queries';
+export * from './use-create-admin-form';
 export * from './use-create-schedule-form';
 export * from './use-create-inspector-form';
 export * from './use-manage-cleaning-service';
@@ -20,4 +21,6 @@ export {
   type Application,
   type InspectionSlot,
   type SlotInfo,
+  type AdminListItem,
+  UserDtoRole,
 } from '../models';

--- a/src/features/admin/viewmodels/queries/index.ts
+++ b/src/features/admin/viewmodels/queries/index.ts
@@ -18,3 +18,7 @@ export * from './use-change-schedule-status';
 export * from './use-change-inspector';
 export * from './use-update-inspector-to-temporary';
 export * from './use-delete-schedule';
+export * from './use-list-admins';
+export * from './use-create-admin';
+export * from './use-delete-admin';
+export * from './use-transfer-super-admin';

--- a/src/features/admin/viewmodels/queries/use-create-admin.ts
+++ b/src/features/admin/viewmodels/queries/use-create-admin.ts
@@ -1,0 +1,29 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { $api } from '@/common/lib';
+
+import { ApiPaths } from '../../models';
+
+export const useCreateAdmin = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('admin', { keyPrefix: 'admins' });
+  const { t: tCommon } = useTranslation('common');
+  return $api.useMutation('post', ApiPaths.AdminController_createAdmin, {
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ['get', ApiPaths.AdminController_listAdmins],
+      }),
+    onError: (error) => {
+      if (error.statusCode === 401) {
+        toast.error(tCommon('error.unauthorized'));
+      } else if (error.statusCode === 409) {
+        toast.error(t('error.conflict'));
+      } else {
+        toast.error(tCommon('error.internalServerError'));
+      }
+    },
+  });
+};

--- a/src/features/admin/viewmodels/queries/use-create-inspector.ts
+++ b/src/features/admin/viewmodels/queries/use-create-inspector.ts
@@ -16,9 +16,6 @@ export const useCreateInspector = () => {
         queryClient.invalidateQueries({
           queryKey: ['get', ApiPaths.InspectorController_getInspectors],
         }),
-        queryClient.invalidateQueries({
-          queryKey: ['get', ApiPaths.ScheduleController_findInspectorsByScheduleUuid],
-        }),
       ]),
     onError: (error) => {
       if (error.statusCode === 401) {

--- a/src/features/admin/viewmodels/queries/use-create-temporary-inspector.ts
+++ b/src/features/admin/viewmodels/queries/use-create-temporary-inspector.ts
@@ -16,9 +16,6 @@ export const useCreateTemporaryInspector = () => {
         queryClient.invalidateQueries({
           queryKey: ['get', ApiPaths.InspectorController_getInspectors],
         }),
-        queryClient.invalidateQueries({
-          queryKey: ['get', ApiPaths.ScheduleController_findInspectorsByScheduleUuid],
-        }),
       ]),
     onError: (error) => {
       if (error.statusCode === 401) {

--- a/src/features/admin/viewmodels/queries/use-delete-admin.ts
+++ b/src/features/admin/viewmodels/queries/use-delete-admin.ts
@@ -1,0 +1,29 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { $api } from '@/common/lib';
+
+import { ApiPaths } from '../../models';
+
+export const useDeleteAdmin = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('admin', { keyPrefix: 'admins' });
+  const { t: tCommon } = useTranslation('common');
+  return $api.useMutation('delete', ApiPaths.AdminController_deleteAdmin, {
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ['get', ApiPaths.AdminController_listAdmins],
+      }),
+    onError: (error) => {
+      if (error.statusCode === 401) {
+        toast.error(tCommon('error.unauthorized'));
+      } else if (error.statusCode === 409) {
+        toast.error(t('error.conflict'));
+      } else {
+        toast.error(tCommon('error.internalServerError'));
+      }
+    },
+  });
+};

--- a/src/features/admin/viewmodels/queries/use-delete-inspector.ts
+++ b/src/features/admin/viewmodels/queries/use-delete-inspector.ts
@@ -16,9 +16,6 @@ export const useDeleteInspector = () => {
         queryClient.invalidateQueries({
           queryKey: ['get', ApiPaths.InspectorController_getInspectors],
         }),
-        queryClient.invalidateQueries({
-          queryKey: ['get', ApiPaths.ScheduleController_findInspectorsByScheduleUuid],
-        }),
       ]),
     onError: (error) => {
       if (error.statusCode === 401) {

--- a/src/features/admin/viewmodels/queries/use-list-admins.ts
+++ b/src/features/admin/viewmodels/queries/use-list-admins.ts
@@ -1,7 +1,30 @@
+import { useEffect } from 'react';
+
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
 import { $api } from '@/common/lib';
 
 import { ApiPaths } from '../../models';
 
 export const useListAdmins = () => {
-  return $api.useQuery('get', ApiPaths.AdminController_listAdmins);
+  const { data, error, isError, isLoading } = $api.useQuery(
+    'get',
+    ApiPaths.AdminController_listAdmins,
+  );
+  const { t } = useTranslation('admin');
+
+  useEffect(() => {
+    if (!isError) return;
+    if (error.statusCode === 401) {
+      toast.error(t('error.unauthorized', { ns: 'common' }));
+    } else {
+      toast.error(t('error.internalServerError', { ns: 'common' }));
+    }
+  }, [error, isError, t]);
+
+  return {
+    data,
+    isLoading,
+  };
 };

--- a/src/features/admin/viewmodels/queries/use-list-admins.ts
+++ b/src/features/admin/viewmodels/queries/use-list-admins.ts
@@ -1,0 +1,7 @@
+import { $api } from '@/common/lib';
+
+import { ApiPaths } from '../../models';
+
+export const useListAdmins = () => {
+  return $api.useQuery('get', ApiPaths.AdminController_listAdmins);
+};

--- a/src/features/admin/viewmodels/queries/use-transfer-super-admin.ts
+++ b/src/features/admin/viewmodels/queries/use-transfer-super-admin.ts
@@ -1,0 +1,34 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { $api } from '@/common/lib';
+
+import { ApiPaths } from '../../models';
+
+export const useTransferSuperAdmin = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('admin', { keyPrefix: 'admins' });
+  const { t: tCommon } = useTranslation('common');
+  return $api.useMutation('post', ApiPaths.AdminController_transferSuperAdmin, {
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['get', ApiPaths.AdminController_listAdmins],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['get', ApiPaths.UserController_getMe],
+        }),
+      ]),
+    onError: (error) => {
+      if (error.statusCode === 401) {
+        toast.error(tCommon('error.unauthorized'));
+      } else if (error.statusCode === 409) {
+        toast.error(t('error.conflict'));
+      } else {
+        toast.error(tCommon('error.internalServerError'));
+      }
+    },
+  });
+};

--- a/src/features/admin/viewmodels/queries/use-update-inspector-to-temporary.ts
+++ b/src/features/admin/viewmodels/queries/use-update-inspector-to-temporary.ts
@@ -17,9 +17,6 @@ export const useUpdateInspectorToTemporary = () => {
         queryClient.invalidateQueries({
           queryKey: ['get', ApiPaths.InspectorController_getInspectors],
         }),
-        queryClient.invalidateQueries({
-          queryKey: ['get', ApiPaths.ScheduleController_findInspectorsByScheduleUuid],
-        }),
       ]),
     onError: (error) => {
       if (error.statusCode === 401) {

--- a/src/features/admin/viewmodels/use-create-admin-form.ts
+++ b/src/features/admin/viewmodels/use-create-admin-form.ts
@@ -1,0 +1,39 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import { useCreateAdmin } from './queries/use-create-admin';
+
+const schema = z.object({
+  name: z.string().min(1),
+  studentNumber: z.string().regex(/^\d{8}$/),
+});
+
+export const useCreateAdminForm = (onSuccess?: () => void) => {
+  const { register, handleSubmit, formState, reset } = useForm({
+    resolver: zodResolver(schema),
+  });
+  const { mutateAsync: createAdmin, isPending } = useCreateAdmin();
+  const { t } = useTranslation('admin', { keyPrefix: 'admins.create' });
+
+  const onSubmit = handleSubmit(
+    async (data) => {
+      await createAdmin({ body: data });
+      toast.success(t('success'));
+      reset();
+      onSuccess?.();
+    },
+    () => {
+      toast.error(t('error.formError'));
+    },
+  );
+
+  return {
+    register,
+    onSubmit,
+    isSubmitting: isPending,
+    errors: formState.errors,
+  };
+};

--- a/src/features/admin/views/frames/admin-layout-frame.tsx
+++ b/src/features/admin/views/frames/admin-layout-frame.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { LanguageToggle } from '@/common/components';
 import { cn } from '@/common/utils';
+import { useAuth } from '@/features/auth';
 
 import { useDatabaseSize } from '../../viewmodels';
 
@@ -47,6 +48,7 @@ function DatabaseSizeBar() {
 
 export function AdminLayoutFrame() {
   const { t } = useTranslation('admin');
+  const { isSuperAdmin } = useAuth();
 
   return (
     <>
@@ -78,6 +80,14 @@ export function AdminLayoutFrame() {
             >
               {t('article.list.nav')}
             </Link>
+            {isSuperAdmin && (
+              <Link
+                to="/admin/admins"
+                className="text-body text-text-secondary hover:bg-bg-surface hover:text-primary rounded-lg px-3 py-2 font-medium transition-colors"
+              >
+                {t('admins.nav')}
+              </Link>
+            )}
           </nav>
           <DatabaseSizeBar />
           <div className="px-2">

--- a/src/features/admin/views/frames/admin-management-frame.tsx
+++ b/src/features/admin/views/frames/admin-management-frame.tsx
@@ -1,0 +1,243 @@
+import { useTransition } from 'react';
+
+import dayjs from 'dayjs';
+import { Crown, Trash } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button, Dialog, Input, Loading } from '@/common/components';
+import { overlay, useOverlayContext } from '@/common/lib';
+import { cn } from '@/common/utils';
+import { useAuth } from '@/features/auth';
+
+import {
+  useCreateAdminForm,
+  useDeleteAdmin,
+  useListAdmins,
+  useTransferSuperAdmin,
+  UserDtoRole,
+  type AdminListItem,
+} from '../../viewmodels';
+
+function AdminRoleBadge({ role }: { role: UserDtoRole }) {
+  const { t } = useTranslation('admin', { keyPrefix: 'admins.role' });
+  return (
+    <span
+      className={cn(
+        'text-body rounded-full px-2.5 py-0.5 font-medium',
+        role === UserDtoRole.SUPERADMIN && 'bg-primary-light text-primary',
+        role === UserDtoRole.ADMIN && 'bg-border text-text-secondary',
+      )}
+    >
+      {role === UserDtoRole.SUPERADMIN ? t('superadmin') : t('admin')}
+    </span>
+  );
+}
+
+function CreateAdminDialog() {
+  const { close } = useOverlayContext();
+  const { t } = useTranslation('admin', { keyPrefix: 'admins.create' });
+  const { register, onSubmit, isSubmitting, errors } = useCreateAdminForm(close);
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <Dialog.Header>
+        <Dialog.Title>{t('title')}</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.Body className="flex flex-col gap-4">
+        <label>
+          {t('name.label')}
+          <Input
+            error={errors.name?.message}
+            placeholder={t('name.placeholder')}
+            {...register('name')}
+          />
+        </label>
+        <label>
+          {t('studentNumber.label')}
+          <Input
+            error={errors.studentNumber?.message}
+            placeholder={t('studentNumber.placeholder')}
+            {...register('studentNumber')}
+          />
+        </label>
+      </Dialog.Body>
+      <Dialog.Footer>
+        <Dialog.Close asChild>
+          <Button type="button" variant="subtle" disabled={isSubmitting}>
+            {t('cancel')}
+          </Button>
+        </Dialog.Close>
+        <Button type="submit" className="w-full" disabled={isSubmitting}>
+          {t('submit')}
+        </Button>
+      </Dialog.Footer>
+    </form>
+  );
+}
+
+function DeleteAdminDialog({ admin }: { admin: AdminListItem }) {
+  const { mutateAsync: deleteAdmin } = useDeleteAdmin();
+  const [loading, startLoading] = useTransition();
+  const { close } = useOverlayContext();
+  const { t } = useTranslation('admin', { keyPrefix: 'admins.actions.delete' });
+
+  return (
+    <>
+      <Dialog.Header>
+        <Dialog.Title>{t('title')}</Dialog.Title>
+        <Dialog.Description>{t('description', { name: admin.name })}</Dialog.Description>
+      </Dialog.Header>
+      <Dialog.Footer>
+        <Dialog.Close asChild>
+          <Button variant="subtle" disabled={loading}>
+            {t('cancel')}
+          </Button>
+        </Dialog.Close>
+        <Button
+          className="w-full"
+          variant="failed"
+          disabled={loading}
+          onClick={() =>
+            startLoading(() =>
+              deleteAdmin({ params: { path: { userUuid: admin.uuid } } })
+                .then(close)
+                .catch(() => {}),
+            )
+          }
+        >
+          {t('submit')}
+        </Button>
+      </Dialog.Footer>
+    </>
+  );
+}
+
+function TransferSuperAdminDialog({ admin }: { admin: AdminListItem }) {
+  const { mutateAsync: transferSuperAdmin } = useTransferSuperAdmin();
+  const { refetchUser } = useAuth();
+  const [loading, startLoading] = useTransition();
+  const { close } = useOverlayContext();
+  const { t } = useTranslation('admin', { keyPrefix: 'admins.actions.transfer' });
+
+  return (
+    <>
+      <Dialog.Header>
+        <Dialog.Title>{t('title')}</Dialog.Title>
+        <Dialog.Description>{t('description', { name: admin.name })}</Dialog.Description>
+      </Dialog.Header>
+      <Dialog.Footer>
+        <Dialog.Close asChild>
+          <Button variant="subtle" disabled={loading}>
+            {t('cancel')}
+          </Button>
+        </Dialog.Close>
+        <Button
+          className="w-full"
+          disabled={loading}
+          onClick={() =>
+            startLoading(() =>
+              transferSuperAdmin({ body: { targetUserUuid: admin.uuid } })
+                .then(() => refetchUser())
+                .then(close)
+                .catch(() => {}),
+            )
+          }
+        >
+          {t('submit')}
+        </Button>
+      </Dialog.Footer>
+    </>
+  );
+}
+
+export function AdminManagementFrame() {
+  const { t } = useTranslation('admin', { keyPrefix: 'admins' });
+  const { data, isLoading } = useListAdmins();
+  const admins = data?.admins ?? [];
+
+  return (
+    <main className="flex flex-1 flex-col gap-4 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-title3 text-text-primary font-semibold">{t('title')}</h1>
+        <Button
+          onClick={() =>
+            overlay.open(() => (
+              <Dialog.Root>
+                <CreateAdminDialog />
+              </Dialog.Root>
+            ))
+          }
+        >
+          {t('add')}
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <Loading containerClassName="h-full" />
+      ) : admins.length === 0 ? (
+        <div className="text-body text-text-secondary">{t('empty')}</div>
+      ) : (
+        <div className="bg-bg border-border overflow-hidden rounded-xl border">
+          <table className="[&_td,&_th]:border-border w-full text-center [&_td,&_th]:border [&_td,&_th]:px-3 [&_td,&_th]:py-2">
+            <thead>
+              <tr className="bg-bg-surface/80 [&_th]:text-text-primary [&_th]:font-medium">
+                <th>{t('columns.name')}</th>
+                <th>{t('columns.email')}</th>
+                <th>{t('columns.studentNumber')}</th>
+                <th>{t('columns.role')}</th>
+                <th>{t('columns.createdAt')}</th>
+                <th>{t('columns.actions')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {admins.map((admin) => (
+                <tr key={admin.uuid}>
+                  <td>{admin.name}</td>
+                  <td>{admin.email}</td>
+                  <td>{admin.studentNumber}</td>
+                  <td>
+                    <AdminRoleBadge role={admin.role} />
+                  </td>
+                  <td>{dayjs(admin.createdAt).format('YYYY-MM-DD HH:mm')}</td>
+                  <td>
+                    {admin.role === UserDtoRole.ADMIN && (
+                      <div className="flex justify-center gap-2">
+                        <Button
+                          size="icon"
+                          title={t('actions.transfer.title')}
+                          onClick={() =>
+                            overlay.open(() => (
+                              <Dialog.Root>
+                                <TransferSuperAdminDialog admin={admin} />
+                              </Dialog.Root>
+                            ))
+                          }
+                        >
+                          <Crown />
+                        </Button>
+                        <Button
+                          size="icon"
+                          className="bg-red-600"
+                          title={t('actions.delete.title')}
+                          onClick={() =>
+                            overlay.open(() => (
+                              <Dialog.Root>
+                                <DeleteAdminDialog admin={admin} />
+                              </Dialog.Root>
+                            ))
+                          }
+                        >
+                          <Trash />
+                        </Button>
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/features/admin/views/frames/admin-management-frame.tsx
+++ b/src/features/admin/views/frames/admin-management-frame.tsx
@@ -43,7 +43,7 @@ function CreateAdminDialog() {
       <Dialog.Header>
         <Dialog.Title>{t('title')}</Dialog.Title>
       </Dialog.Header>
-      <Dialog.Body className="flex flex-col gap-4">
+      <Dialog.Body className="flex flex-col gap-4 overflow-y-visible">
         <label>
           {t('name.label')}
           <Input

--- a/src/features/admin/views/frames/index.ts
+++ b/src/features/admin/views/frames/index.ts
@@ -14,3 +14,4 @@ export * from './create-article-frame';
 export * from './edit-article-frame';
 export * from './room-list-frame';
 export * from './time-list-frame';
+export * from './admin-management-frame';

--- a/src/features/auth/viewmodels/use-auth.ts
+++ b/src/features/auth/viewmodels/use-auth.ts
@@ -41,17 +41,14 @@ export const useAuth = ({ showToast = false }: { showToast?: boolean } = {}) => 
     return userData;
   }, [userData, userError, isLoading, token]);
 
-  const isAdmin = useMemo(
-    () =>
-      user === undefined
-        ? undefined
-        : user?.role === UserDtoRole.ADMIN || user?.role === UserDtoRole.SUPERADMIN,
-    [user],
-  );
-
   const isSuperAdmin = useMemo(
     () => (user === undefined ? undefined : user?.role === UserDtoRole.SUPERADMIN),
     [user],
+  );
+
+  const isAdmin = useMemo(
+    () => isSuperAdmin || (user === undefined ? undefined : user?.role === UserDtoRole.ADMIN),
+    [user, isSuperAdmin],
   );
 
   const isInspector = useMemo(

--- a/src/features/auth/viewmodels/use-auth.ts
+++ b/src/features/auth/viewmodels/use-auth.ts
@@ -42,7 +42,15 @@ export const useAuth = ({ showToast = false }: { showToast?: boolean } = {}) => 
   }, [userData, userError, isLoading, token]);
 
   const isAdmin = useMemo(
-    () => (user === undefined ? undefined : user?.role === UserDtoRole.ADMIN),
+    () =>
+      user === undefined
+        ? undefined
+        : user?.role === UserDtoRole.ADMIN || user?.role === UserDtoRole.SUPERADMIN,
+    [user],
+  );
+
+  const isSuperAdmin = useMemo(
+    () => (user === undefined ? undefined : user?.role === UserDtoRole.SUPERADMIN),
     [user],
   );
 
@@ -61,6 +69,7 @@ export const useAuth = ({ showToast = false }: { showToast?: boolean } = {}) => 
     user,
     isInspector,
     isAdmin,
+    isSuperAdmin,
     refetchUser,
     idpLogIn,
     idpLogOut,

--- a/src/routes/_auth-required/admin/admins/index.tsx
+++ b/src/routes/_auth-required/admin/admins/index.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute, Navigate } from '@tanstack/react-router';
+
+import { Loading } from '@/common/components';
+import { AdminManagementFrame } from '@/features/admin';
+import { useAuth } from '@/features/auth';
+
+export const Route = createFileRoute('/_auth-required/admin/admins/')({
+  component: AdminsRoute,
+});
+
+function AdminsRoute() {
+  const { isAdmin, isSuperAdmin } = useAuth({ showToast: true });
+
+  if (isAdmin === undefined || isSuperAdmin === undefined) return <Loading />;
+  if (!isAdmin) return <Navigate to="/" replace />;
+  if (!isSuperAdmin) return <Navigate to="/admin" replace />;
+
+  return <AdminManagementFrame />;
+}


### PR DESCRIPTION


https://github.com/user-attachments/assets/77a19549-1aa1-450d-8f12-abaa4be00ca9


## Summary
- Add `/admin/admins` page for SUPERADMIN to list, add, remove admins and transfer superadmin role.
- Show admin management nav link only when the current user is SUPERADMIN.
- Treat SUPERADMIN as admin in `useAuth` for admin area access.

## Test plan
- [x] Log in as SUPERADMIN and confirm the admin header shows the admin management link.
- [x] Open `/admin/admins` and verify the admin list loads.
- [x] Add an admin by name and student number.
- [x] Remove an ADMIN row and confirm it disappears from the list.
- [x] Transfer superadmin to another ADMIN and confirm role changes after refresh.
- [x] Log in as regular ADMIN and confirm the nav link is hidden and `/admin/admins` redirects to `/admin`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 관리 페이지 추가: 슈퍼관리자가 관리자 목록 조회, 추가, 삭제 및 슈퍼관리자 전환 가능
  * 관리자 생성 폼 및 관련 UI(대화상자, 테이블, 배지) 추가
  * 권한 검사 강화: isSuperAdmin 반환값 추가 및 네비게이션 노출 제어
* **문서**
  * 관리자용 영어/한국어 로케일 문자열 추가
* **버그 수정**
  * 인스펙터 관련 쿼리 무효화 대상 수정(올바른 엔드포인트 키로 변경)
* **기타**
  * 패키지 버전 소폭 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsainfoteam/house-moving-out-fe/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->