### PR TITLE
fix(admin): treat cleaning service rooms as completed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "house-moving-out-fe",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -335,6 +335,7 @@
     "statistics": {
       "all_not_inspected": "All not inspected",
       "all_passed": "All passed",
+      "all_cleaning_service": "Cleaning service rooms",
       "all_single_target": "All not inspected single",
       "all_waiting_target": "All waiting inspection",
       "count": "Male/Female target count",

--- a/public/locales/ko/admin.json
+++ b/public/locales/ko/admin.json
@@ -334,6 +334,7 @@
     "statistics": {
       "all_not_inspected": "전체 퇴사검사 미이행 수",
       "all_passed": "검사 완료된 방 수",
+      "all_cleaning_service": "위탁청소 방 수",
       "all_single_target": "전체 1인퇴사 검사 수",
       "all_waiting_target": "검사 예정 방 수",
       "count": "남자층/여자층 검사대상 수",

--- a/src/features/admin/views/frames/schedule-detail-frame.tsx
+++ b/src/features/admin/views/frames/schedule-detail-frame.tsx
@@ -108,7 +108,7 @@ export function ScheduleDetailFrame() {
 
   const counts = countBy(targets, (target) => {
     if (target.inspectionType === InspectionType.EMPTY) return 'empty';
-    if (target.status === ApplicationStatus.PASSED) return 'passed';
+    if (target.status === ApplicationStatus.PASSED || target.applyCleaningService) return 'passed';
     if (target.lastInspectionTime) {
       if (target.inspectionType !== InspectionType.SOLO) return 'waiting';
       return 'solo_waiting';
@@ -117,9 +117,12 @@ export function ScheduleDetailFrame() {
     return 'solo_not_inspected';
   });
   const genderCounts = countBy(
-    targets.filter((t) => t.inspectionType !== InspectionType.EMPTY),
+    targets.filter((t) => t.inspectionType !== InspectionType.EMPTY && !t.applyCleaningService),
     (target) => target.gender,
   );
+  const cleaningServiceCount = targets.filter(
+    (t) => t.inspectionType !== InspectionType.EMPTY && t.applyCleaningService,
+  ).length;
 
   const changeSchedule = (status: ScheduleStatus) => () => {
     overlay.open(({ close }) => (
@@ -252,11 +255,17 @@ export function ScheduleDetailFrame() {
               <span className="font-medium">{counts.passed ?? 0}</span>
             </div>
             <div className="text-body text-text-primary flex justify-between">
-              <span className="text-text-secondary">{t('schedule.statistics.progress')}</span>
-              <span className="font-medium">
-                {targets.length ? Math.ceil(((counts.passed ?? 0) / targets.length) * 100) : 0}%
+              <span className="text-text-secondary">
+                {t('schedule.statistics.all_cleaning_service')}
               </span>
+              <span className="font-medium">{cleaningServiceCount}</span>
             </div>
+          </div>
+          <div className="text-body text-text-primary mt-1 flex justify-between border-t border-gray-100 pt-3">
+            <span className="text-text-secondary">{t('schedule.statistics.progress')}</span>
+            <span className="font-medium">
+              {targets.length ? Math.ceil(((counts.passed ?? 0) / targets.length) * 100) : 0}%
+            </span>
           </div>
         </div>
       </section>

--- a/src/features/admin/views/frames/target-list-frame.tsx
+++ b/src/features/admin/views/frames/target-list-frame.tsx
@@ -88,6 +88,8 @@ export function TargetListFrame() {
             {targets
               .filter((t) => t.inspectionType !== InspectionType.EMPTY)
               .map((target) => {
+                const cleaningServiceApplied =
+                  isDraftCleaning(target.uuid) ?? target.applyCleaningService;
                 return (
                   <tr key={target.roomNumber}>
                     <td className={cn('[&&]:border-r-2')}>{target.roomNumber}</td>
@@ -113,7 +115,7 @@ export function TargetListFrame() {
                         {isEditable ? (
                           <Checkbox
                             className="scale-100"
-                            checked={isDraftCleaning(target.uuid) ?? target.applyCleaningService}
+                            checked={cleaningServiceApplied}
                             onChange={(event) => {
                               handleCleaningServiceChange(
                                 target.uuid,
@@ -124,7 +126,7 @@ export function TargetListFrame() {
                             disabled={!isEditable || isSaving}
                             aria-label={t('target.detail.cleaningService')}
                           />
-                        ) : target.applyCleaningService ? (
+                        ) : cleaningServiceApplied ? (
                           <Check
                             className="text-primary size-5"
                             aria-label={t('target.detail.cleaningService')}
@@ -157,7 +159,11 @@ export function TargetListFrame() {
                       </div>
                     </td>
                     <td>
-                      {isNil(target.status) ? '-' : t(`result.${target.status.toLowerCase()}`)}
+                      {cleaningServiceApplied
+                        ? t('result.passed')
+                        : isNil(target.status)
+                          ? '-'
+                          : t(`result.${target.status.toLowerCase()}`)}
                     </td>
                     <td>
                       {target.lastInspectionTime


### PR DESCRIPTION

<img width="1051" height="456" alt="CleanShot 2026-06-21 at 20 49 57" src="https://github.com/user-attachments/assets/ddd6b86a-5408-44d3-bafa-94df7c12e215" />


위탁청소 호실은 퇴검을 받지 않으므로 완료로 처리한다.

- 대시보드 통계: 위탁청소 호실을 passed로 집계해 미이행/예정 수에서 제외
- 검사 대상자 목록: 위탁청소 체크 시 결과 컬럼을 통과(완료)로 표시 (드래프트 포함)
- 남자층/여자층 검사대상 수에서 위탁청소 호실 제외
- "위탁청소 방 수" 통계 추가 및 진행률을 하단 전체폭 행으로 분리

HMF-129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 청소 서비스 통계를 별도 지표로 집계하여 더욱 상세한 스케줄 통계 정보 제공

* **Bug Fixes**
  * 스케줄 통계 계산 로직 수정으로 청소 서비스 적용 대상이 정확하게 반영되도록 개선
  * 대상 목록에서 청소 서비스 적용 상태 표시 로직 개선

* **Chores**
  * 패키지 버전 업데이트 (0.5.9 → 0.5.10)
  * 영문/한국어 번역 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->